### PR TITLE
Refactor wires to arena storage

### DIFF
--- a/src/circuits/basic.rs
+++ b/src/circuits/basic.rs
@@ -1,4 +1,5 @@
 use crate::bag::*;
+use crate::core::wire::WireOps;
 
 pub fn half_adder(a: Wirex, b: Wirex) -> Circuit {
     let result = new_wirex();
@@ -100,6 +101,7 @@ pub fn multiplexer(a: Wires, s: Wires, w: usize) -> Circuit {
 
 #[cfg(test)]
 mod tests {
+    use crate::core::wire::WireOps;
     use rand::{Rng, rng};
 
     use crate::{
@@ -120,10 +122,10 @@ mod tests {
 
         for ((a, b), (c, d)) in result {
             let a_wire = new_wirex();
-            a_wire.borrow_mut().set(a);
+            a_wire.set(a);
 
             let b_wire = new_wirex();
-            b_wire.borrow_mut().set(b);
+            b_wire.set(b);
 
             let circuit = half_adder(a_wire, b_wire);
 
@@ -133,8 +135,8 @@ mod tests {
 
             let (c_wire, d_wire) = (circuit.0[0].clone(), circuit.0[1].clone());
 
-            assert_eq!(c_wire.borrow().get_value(), c);
-            assert_eq!(d_wire.borrow().get_value(), d);
+            assert_eq!(c_wire.get_value(), c);
+            assert_eq!(d_wire.get_value(), d);
         }
     }
 
@@ -153,13 +155,13 @@ mod tests {
 
         for ((a, b, c), (d, e)) in result {
             let a_wire = new_wirex();
-            a_wire.borrow_mut().set(a);
+            a_wire.set(a);
 
             let b_wire = new_wirex();
-            b_wire.borrow_mut().set(b);
+            b_wire.set(b);
 
             let c_wire = new_wirex();
-            c_wire.borrow_mut().set(c);
+            c_wire.set(c);
 
             let circuit = full_adder(a_wire, b_wire, c_wire);
 
@@ -169,8 +171,8 @@ mod tests {
 
             let (d_wire, e_wire) = (circuit.0[0].clone(), circuit.0[1].clone());
 
-            assert_eq!(d_wire.borrow().get_value(), d);
-            assert_eq!(e_wire.borrow().get_value(), e);
+            assert_eq!(d_wire.get_value(), d);
+            assert_eq!(e_wire.get_value(), e);
         }
     }
 
@@ -185,10 +187,10 @@ mod tests {
 
         for ((a, b), (c, d)) in result {
             let a_wire = new_wirex();
-            a_wire.borrow_mut().set(a);
+            a_wire.set(a);
 
             let b_wire = new_wirex();
-            b_wire.borrow_mut().set(b);
+            b_wire.set(b);
 
             let circuit = half_subtracter(a_wire, b_wire);
 
@@ -198,8 +200,8 @@ mod tests {
 
             let (c_wire, d_wire) = (circuit.0[0].clone(), circuit.0[1].clone());
 
-            assert_eq!(c_wire.borrow().get_value(), c);
-            assert_eq!(d_wire.borrow().get_value(), d);
+            assert_eq!(c_wire.get_value(), c);
+            assert_eq!(d_wire.get_value(), d);
         }
     }
 
@@ -218,13 +220,13 @@ mod tests {
 
         for ((a, b, c), (d, e)) in result {
             let a_wire = new_wirex();
-            a_wire.borrow_mut().set(a);
+            a_wire.set(a);
 
             let b_wire = new_wirex();
-            b_wire.borrow_mut().set(b);
+            b_wire.set(b);
 
             let c_wire = new_wirex();
-            c_wire.borrow_mut().set(c);
+            c_wire.set(c);
 
             let circuit = full_subtracter(a_wire, b_wire, c_wire);
 
@@ -234,8 +236,8 @@ mod tests {
 
             let (d_wire, e_wire) = (circuit.0[0].clone(), circuit.0[1].clone());
 
-            assert_eq!(d_wire.borrow().get_value(), d);
-            assert_eq!(e_wire.borrow().get_value(), e);
+            assert_eq!(d_wire.get_value(), d);
+            assert_eq!(e_wire.get_value(), e);
         }
     }
 
@@ -254,13 +256,13 @@ mod tests {
 
         for ((a, b, c), d) in result {
             let a_wire = new_wirex();
-            a_wire.borrow_mut().set(a);
+            a_wire.set(a);
 
             let b_wire = new_wirex();
-            b_wire.borrow_mut().set(b);
+            b_wire.set(b);
 
             let c_wire = new_wirex();
-            c_wire.borrow_mut().set(c);
+            c_wire.set(c);
 
             let circuit = selector(a_wire, b_wire, c_wire);
 
@@ -270,7 +272,7 @@ mod tests {
 
             let d_wire = circuit.0[0].clone();
 
-            assert_eq!(d_wire.borrow().get_value(), d);
+            assert_eq!(d_wire.get_value(), d);
         }
     }
 
@@ -282,14 +284,14 @@ mod tests {
         let s: Wires = (0..w).map(|_| new_wirex()).collect();
 
         for wire in a.clone() {
-            wire.borrow_mut().set(rng().random());
+            wire.set(rng().random());
         }
 
         let mut u = 0;
         for wire in s.iter().rev() {
             let x = rng().random();
             u = u + u + if x { 1 } else { 0 };
-            wire.borrow_mut().set(x);
+            wire.set(x);
         }
 
         let circuit = multiplexer(a.clone(), s.clone(), w);
@@ -299,8 +301,8 @@ mod tests {
             gate.evaluate();
         }
 
-        let result = circuit.0[0].clone().borrow().get_value();
-        let expected = a[u].clone().borrow().get_value();
+        let result = circuit.0[0].get_value();
+        let expected = a[u].get_value();
 
         assert_eq!(result, expected);
     }

--- a/src/circuits/bigint/add.rs
+++ b/src/circuits/bigint/add.rs
@@ -1,4 +1,5 @@
 use super::BigIntImpl;
+use crate::core::wire::with_arena;
 use crate::{
     bag::*,
     circuits::{
@@ -35,7 +36,7 @@ pub fn optimized_sub_generic(
 
     let mut circuit = Circuit::empty();
 
-    let mut want: Rc<RefCell<Wire>> = new_wirex();
+    let mut want: Wirex = new_wirex();
     for i in 0..len {
         circuit.add_wire(new_wirex());
         if i > 0 {
@@ -75,7 +76,7 @@ pub fn optimized_sub_generic(
                 a_wires[i].clone(),
                 circuit.0[i].clone(),
             ));
-            let new_want: Rc<RefCell<Wire>> = new_wirex();
+            let new_want: Wirex = new_wirex();
             circuit.add(Gate::nimp(
                 b_wires[i].clone(),
                 a_wires[i].clone(),
@@ -308,6 +309,7 @@ mod tests {
             biguint_from_bits, biguint_from_wires, biguint_two_pow_254, random_biguint_n_bits,
         },
     };
+    use crate::core::wire::{WireOps, with_arena};
     use num_bigint::BigUint;
     use std::str::FromStr;
 
@@ -461,13 +463,13 @@ mod tests {
                 gate.evaluate();
             }
             if a < b {
-                assert!(!bound_check.borrow().get_value());
+                assert!(!with_arena(|wires| wires[bound_check].get_value()));
             } else {
-                assert!(bound_check.borrow().get_value());
+                assert!(with_arena(|wires| wires[bound_check].get_value()));
                 let result = biguint_from_bits(
                     output_wires
                         .iter()
-                        .map(|output_wire| output_wire.borrow().get_value())
+                        .map(|output_wire| with_arena(|wires| wires[*output_wire].get_value()))
                         .collect(),
                 );
                 assert_eq!(result, a - b);

--- a/src/circuits/bigint/cmp.rs
+++ b/src/circuits/bigint/cmp.rs
@@ -1,6 +1,7 @@
 use super::BigIntImpl;
 use crate::circuits::basic::multiplexer;
 use crate::circuits::bigint::utils::bits_from_biguint;
+use crate::core::wire::WireOps;
 use crate::{bag::*, circuits::basic::selector};
 use num_bigint::BigUint;
 
@@ -116,7 +117,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
         bits.resize(Self::N_BITS, false);
         for i in 0..Self::N_BITS {
             bit_wires.push(new_wirex());
-            bit_wires[i].borrow_mut().set(bits[i]);
+            bit_wires[i].set(bits[i]);
         }
         Self::self_or_zero(bit_wires, s)
     }
@@ -142,6 +143,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
 #[cfg(test)]
 mod tests {
+    use crate::core::wire::WireOps;
     use rand::{Rng, rng};
     use std::str::FromStr;
 
@@ -163,7 +165,7 @@ mod tests {
         for mut gate in circuit.1 {
             gate.evaluate();
         }
-        assert_eq!(a == b, circuit.0[0].borrow().get_value());
+        assert_eq!(a == b, circuit.0[0].get_value());
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::equal(
@@ -174,7 +176,7 @@ mod tests {
         for mut gate in circuit.1 {
             gate.evaluate();
         }
-        assert!(circuit.0[0].borrow().get_value());
+        assert!(circuit.0[0].get_value());
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::equal_constant(U254::wires_set_from_number(a.clone()), b.clone());
@@ -182,7 +184,7 @@ mod tests {
         for mut gate in circuit.1 {
             gate.evaluate();
         }
-        assert_eq!(a == b, circuit.0[0].borrow().get_value());
+        assert_eq!(a == b, circuit.0[0].get_value());
     }
 
     #[test]
@@ -197,7 +199,7 @@ mod tests {
         for mut gate in circuit.1 {
             gate.evaluate();
         }
-        assert_eq!(a > b, circuit.0[0].borrow().get_value());
+        assert_eq!(a > b, circuit.0[0].get_value());
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
@@ -208,7 +210,7 @@ mod tests {
         for mut gate in circuit.1 {
             gate.evaluate();
         }
-        assert!(!circuit.0[0].borrow().get_value());
+        assert!(!circuit.0[0].get_value());
 
         let a = random_biguint_n_bits(254);
         let circuit = U254::greater_than(
@@ -219,7 +221,7 @@ mod tests {
         for mut gate in circuit.1 {
             gate.evaluate();
         }
-        assert!(circuit.0[0].borrow().get_value());
+        assert!(circuit.0[0].get_value());
     }
 
     #[test]
@@ -231,7 +233,7 @@ mod tests {
         for mut gate in circuit.1 {
             gate.evaluate();
         }
-        assert_eq!(a < b, circuit.0[0].borrow().get_value());
+        assert_eq!(a < b, circuit.0[0].get_value());
     }
 
     #[test]
@@ -239,7 +241,7 @@ mod tests {
         let a = random_biguint_n_bits(254);
         let b = random_biguint_n_bits(254);
         let s = new_wirex();
-        s.borrow_mut().set(true);
+        s.set(true);
         let circuit = U254::select(
             U254::wires_set_from_number(a.clone()),
             U254::wires_set_from_number(b.clone()),
@@ -258,7 +260,7 @@ mod tests {
         let a = random_biguint_n_bits(254);
 
         let s = new_wirex();
-        s.borrow_mut().set(true);
+        s.set(true);
         let circuit = U254::self_or_zero(U254::wires_set_from_number(a.clone()), s);
         circuit.gate_counts().print();
         for mut gate in circuit.1 {
@@ -268,7 +270,7 @@ mod tests {
         assert_eq!(a, c);
 
         let s = new_wirex();
-        s.borrow_mut().set(false);
+        s.set(false);
         let circuit = U254::self_or_zero(U254::wires_set_from_number(a.clone()), s);
         for mut gate in circuit.1 {
             gate.evaluate();
@@ -293,7 +295,7 @@ mod tests {
         for wire in s.iter().rev() {
             let x = rng().random();
             u = u + u + if x { 1 } else { 0 };
-            wire.borrow_mut().set(x);
+            wire.set(x);
         }
 
         let circuit = U254::multiplexer(a_wires, s.clone(), w);

--- a/src/circuits/bigint/mod.rs
+++ b/src/circuits/bigint/mod.rs
@@ -1,3 +1,4 @@
+use crate::core::wire::WireOps;
 use crate::{
     bag::*,
     circuits::bigint::utils::{bits_from_biguint, n_wires},
@@ -21,7 +22,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()

--- a/src/circuits/bigint/mul.rs
+++ b/src/circuits/bigint/mul.rs
@@ -1,4 +1,5 @@
 use super::BigIntImpl;
+use crate::core::wire::WireOps;
 use crate::{
     bag::*,
     circuits::bigint::{
@@ -17,7 +18,7 @@ static KARATSUBA_DECISIONS: Lazy<Mutex<[Option<bool>; 256]>> =
 
 fn extend_with_false(wires: &mut Wires) {
     let zero_wire = new_wirex();
-    zero_wire.borrow_mut().set(false);
+    zero_wire.set(false);
     wires.push(zero_wire);
 }
 
@@ -38,7 +39,7 @@ pub fn mul_generic(a_wires: &Wires, b_wires: &Wires, len: usize) -> Circuit {
     let mut circuit = Circuit::empty();
     for _ in 0..(len * 2) {
         let wire = new_wirex();
-        wire.borrow_mut().set(false);
+        wire.set(false);
         circuit.add_wire(wire)
     } //this part can be optimized later 
 
@@ -76,7 +77,7 @@ pub fn mul_karatsuba_generic(a_wires: &Wires, b_wires: &Wires, len: usize) -> Ci
         let mut circuit = Circuit::empty();
         circuit.0 = n_wires(len * 2);
         for i in 0..len * 2 {
-            circuit.0[i].borrow_mut().set(false);
+            circuit.0[i].set(false);
         }
 
         let len_0 = len / 2;
@@ -164,7 +165,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
         for _ in 0..(N_BITS * 2) {
             let wire = new_wirex();
-            wire.borrow_mut().set(false);
+            wire.set(false);
             circuit.add_wire(wire)
         } //this part can be optimized later 
 
@@ -215,7 +216,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
         for _ in 0..power {
             let wire = new_wirex();
-            wire.borrow_mut().set(false);
+            wire.set(false);
             circuit.add_wire(wire)
         } //this part can be optimized later 
 
@@ -248,6 +249,7 @@ impl<const N_BITS: usize> BigIntImpl<N_BITS> {
 
 #[cfg(test)]
 mod tests {
+    use crate::core::wire::WireOps;
     use std::str::FromStr;
 
     use num_bigint::BigUint;
@@ -279,7 +281,7 @@ mod tests {
                 circuit
                     .0
                     .iter()
-                    .map(|output_wire| output_wire.borrow().get_value())
+                    .map(|output_wire| output_wire.get_value())
                     .collect(),
             );
             assert_eq!(result, c);
@@ -306,7 +308,7 @@ mod tests {
                 circuit
                     .0
                     .iter()
-                    .map(|output_wire| output_wire.borrow().get_value())
+                    .map(|output_wire| output_wire.get_value())
                     .collect(),
             );
             assert_eq!(result, c);
@@ -336,7 +338,7 @@ mod tests {
                 circuit
                     .0
                     .iter()
-                    .map(|output_wire| output_wire.borrow().get_value())
+                    .map(|output_wire| output_wire.get_value())
                     .collect(),
             );
             assert_eq!(result, c);
@@ -360,7 +362,7 @@ mod tests {
                 circuit
                     .0
                     .iter()
-                    .map(|output_wire| output_wire.borrow().get_value())
+                    .map(|output_wire| output_wire.get_value())
                     .collect(),
             );
             assert_eq!(result, c);
@@ -389,7 +391,7 @@ mod tests {
                 circuit
                     .0
                     .iter()
-                    .map(|output_wire| output_wire.borrow().get_value())
+                    .map(|output_wire| output_wire.get_value())
                     .collect(),
             );
             assert_eq!(result, c);

--- a/src/circuits/bigint/utils.rs
+++ b/src/circuits/bigint/utils.rs
@@ -1,4 +1,5 @@
 use crate::bag::*;
+use crate::core::wire::WireOps;
 use num_bigint::BigUint;
 use rand::{Rng, rng};
 use std::str::FromStr;
@@ -49,7 +50,7 @@ pub fn n_wires(n: usize) -> Wires {
 }
 
 pub fn biguint_from_wires(wires: Wires) -> BigUint {
-    biguint_from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+    biguint_from_bits(wires.iter().map(|wire| wire.get_value()).collect())
 }
 
 pub fn change_to_neg_pos_decomposition(bits: Vec<bool>) -> Vec<i8> {

--- a/src/circuits/bn254/fp254impl.rs
+++ b/src/circuits/bn254/fp254impl.rs
@@ -1,3 +1,4 @@
+use crate::core::wire::WireOps;
 use crate::{
     bag::*,
     circuits::{
@@ -527,8 +528,8 @@ pub trait Fp254Impl {
         let mut result = Fq::wires();
         let mut r1 = new_wirex();
         let mut r2 = new_wirex();
-        r1.borrow_mut().set(false);
-        r2.borrow_mut().set(false);
+        r1.set(false);
+        r2.set(false);
         for i in 0..U254::N_BITS {
             // msb to lsb
             let j = U254::N_BITS - 1 - i;

--- a/src/circuits/bn254/fq.rs
+++ b/src/circuits/bn254/fq.rs
@@ -1,3 +1,4 @@
+use crate::core::wire::WireOps;
 use crate::{bag::*, circuits::bn254::fp254impl::Fp254Impl};
 use ark_ff::UniformRand;
 use ark_std::rand::SeedableRng;
@@ -76,7 +77,7 @@ impl Fq {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()
@@ -87,7 +88,7 @@ impl Fq {
     }
 
     pub fn from_wires(wires: Wires) -> ark_bn254::Fq {
-        Self::from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_montgomery_wires(wires: Wires) -> ark_bn254::Fq {
@@ -98,6 +99,7 @@ impl Fq {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::wire::WireOps;
     use ark_ff::{AdditiveGroup, Field};
 
     #[test]

--- a/src/circuits/bn254/fq12.rs
+++ b/src/circuits/bn254/fq12.rs
@@ -1,3 +1,4 @@
+use crate::core::wire::WireOps;
 use crate::{
     bag::*,
     circuits::bn254::{fp254impl::Fp254Impl, fq::Fq, fq2::Fq2, fq6::Fq6},
@@ -48,7 +49,7 @@ impl Fq12 {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()
@@ -59,7 +60,7 @@ impl Fq12 {
     }
 
     pub fn from_wires(wires: Wires) -> ark_bn254::Fq12 {
-        Self::from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_montgomery_wires(wires: Wires) -> ark_bn254::Fq12 {
@@ -798,6 +799,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+    use crate::core::wire::WireOps;
     use ark_ff::{CyclotomicMultSubgroup, Field};
     use num_bigint::BigUint;
     use serial_test::serial;
@@ -821,7 +823,7 @@ mod tests {
         for mut gate in circuit.1 {
             gate.evaluate();
         }
-        let result = circuit.0[0].clone().borrow().get_value();
+        let result = circuit.0[0].get_value();
         assert_eq!(result, a == b);
 
         let circuit = Fq12::equal_constant(Fq12::wires_set(a), a);
@@ -829,7 +831,7 @@ mod tests {
         for mut gate in circuit.1 {
             gate.evaluate();
         }
-        let result = circuit.0[0].clone().borrow().get_value();
+        let result = circuit.0[0].get_value();
         assert!(result);
     }
 

--- a/src/circuits/bn254/fq2.rs
+++ b/src/circuits/bn254/fq2.rs
@@ -1,3 +1,4 @@
+use crate::core::wire::WireOps;
 use crate::{
     bag::*,
     circuits::bn254::{fp254impl::Fp254Impl, fq::Fq},
@@ -47,7 +48,7 @@ impl Fq2 {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()
@@ -58,7 +59,7 @@ impl Fq2 {
     }
 
     pub fn from_wires(wires: Wires) -> ark_bn254::Fq2 {
-        Self::from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_montgomery_wires(wires: Wires) -> ark_bn254::Fq2 {
@@ -490,6 +491,7 @@ impl Fq2 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::wire::WireOps;
     use ark_ff::{AdditiveGroup, Fp6Config};
 
     #[test]

--- a/src/circuits/bn254/fq6.rs
+++ b/src/circuits/bn254/fq6.rs
@@ -1,3 +1,4 @@
+use crate::core::wire::WireOps;
 use crate::{bag::*, circuits::bn254::fq2::Fq2};
 use ark_ff::{Fp6Config, UniformRand, fields::AdditiveGroup};
 use ark_std::rand::SeedableRng;
@@ -58,7 +59,7 @@ impl Fq6 {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()
@@ -69,7 +70,7 @@ impl Fq6 {
     }
 
     pub fn from_wires(wires: Wires) -> ark_bn254::Fq6 {
-        Self::from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_montgomery_wires(wires: Wires) -> ark_bn254::Fq6 {
@@ -900,6 +901,7 @@ impl Fq6 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::wire::WireOps;
     use ark_ff::{Field, Fp12Config};
     use serial_test::serial;
 

--- a/src/circuits/bn254/fr.rs
+++ b/src/circuits/bn254/fr.rs
@@ -1,3 +1,4 @@
+use crate::core::wire::WireOps;
 use crate::{bag::*, circuits::bn254::fp254impl::Fp254Impl};
 use ark_ff::UniformRand;
 use ark_std::rand::SeedableRng;
@@ -75,7 +76,7 @@ impl Fr {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()
@@ -86,7 +87,7 @@ impl Fr {
     }
 
     pub fn from_wires(wires: Wires) -> ark_bn254::Fr {
-        Self::from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_montgomery_wires(wires: Wires) -> ark_bn254::Fr {

--- a/src/circuits/bn254/g1.rs
+++ b/src/circuits/bn254/g1.rs
@@ -1,3 +1,4 @@
+use crate::core::wire::WireOps;
 use crate::{
     bag::*,
     circuits::{
@@ -76,7 +77,7 @@ impl G1Projective {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()
@@ -87,11 +88,11 @@ impl G1Projective {
     }
 
     pub fn from_wires(wires: Wires) -> ark_bn254::G1Projective {
-        Self::from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_wires_unchecked(wires: Wires) -> ark_bn254::G1Projective {
-        Self::from_bits_unchecked(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits_unchecked(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_montgomery_wires_unchecked(wires: Wires) -> ark_bn254::G1Projective {
@@ -625,7 +626,7 @@ impl G1Affine {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()
@@ -636,11 +637,11 @@ impl G1Affine {
     }
 
     pub fn from_wires(wires: Wires) -> ark_bn254::G1Affine {
-        Self::from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_wires_unchecked(wires: Wires) -> ark_bn254::G1Affine {
-        Self::from_bits_unchecked(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits_unchecked(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_montgomery_wires_unchecked(wires: Wires) -> ark_bn254::G1Affine {
@@ -709,6 +710,7 @@ pub fn projective_to_affine_evaluate_montgomery(p: Wires) -> (Wires, GateCount) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::wire::WireOps;
     use ark_ec::{CurveGroup, scalar_mul::variable_base::VariableBaseMSM};
     use ark_ff::Field;
     use rand::{Rng, rng};
@@ -927,7 +929,7 @@ mod tests {
         for wire in s.iter().rev() {
             let x = rng().random();
             u = u + u + if x { 1 } else { 0 };
-            wire.borrow_mut().set(x);
+            wire.set(x);
         }
 
         let circuit = G1Projective::multiplexer(a_wires, s.clone(), w);
@@ -959,7 +961,7 @@ mod tests {
         for wire in s.iter().rev() {
             let x = rng().random();
             u = u + u + if x { 1 } else { 0 };
-            wire.borrow_mut().set(x);
+            wire.set(x);
         }
 
         let (result_wires, gate_count) = G1Projective::multiplexer_evaluate(a_wires, s.clone(), w);

--- a/src/circuits/bn254/g2.rs
+++ b/src/circuits/bn254/g2.rs
@@ -1,3 +1,4 @@
+use crate::core::wire::WireOps;
 use crate::{bag::*, circuits::bn254::fq2::Fq2};
 use ark_ff::UniformRand;
 use ark_std::rand::SeedableRng;
@@ -69,7 +70,7 @@ impl G2Projective {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()
@@ -80,11 +81,11 @@ impl G2Projective {
     }
 
     pub fn from_wires(wires: Wires) -> ark_bn254::G2Projective {
-        Self::from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_wires_unchecked(wires: Wires) -> ark_bn254::G2Projective {
-        Self::from_bits_unchecked(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits_unchecked(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_montgomery_wires_unchecked(wires: Wires) -> ark_bn254::G2Projective {
@@ -146,7 +147,7 @@ impl G2Affine {
             .iter()
             .map(|bit| {
                 let wire = new_wirex();
-                wire.borrow_mut().set(*bit);
+                wire.set(*bit);
                 wire
             })
             .collect()
@@ -157,11 +158,11 @@ impl G2Affine {
     }
 
     pub fn from_wires(wires: Wires) -> ark_bn254::G2Affine {
-        Self::from_bits(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_wires_unchecked(wires: Wires) -> ark_bn254::G2Affine {
-        Self::from_bits_unchecked(wires.iter().map(|wire| wire.borrow().get_value()).collect())
+        Self::from_bits_unchecked(wires.iter().map(|wire| wire.get_value()).collect())
     }
 
     pub fn from_montgomery_wires_unchecked(wires: Wires) -> ark_bn254::G2Affine {
@@ -172,6 +173,7 @@ impl G2Affine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::wire::WireOps;
 
     #[test]
     fn test_g2p_random() {

--- a/src/circuits/groth16.rs
+++ b/src/circuits/groth16.rs
@@ -10,6 +10,7 @@ use crate::circuits::bn254::g1::{
 use crate::circuits::bn254::pairing::{
     multi_miller_loop_groth16_evaluate_fast, multi_miller_loop_groth16_evaluate_montgomery_fast,
 };
+use crate::core::wire::WireOps;
 use ark_ec::pairing::Pairing;
 use ark_ec::{AffineRepr, VariableBaseMSM};
 use ark_ff::Field;
@@ -234,7 +235,7 @@ mod tests {
 
         let (result, gate_count) = groth16_verifier_evaluate(public, proof_a, proof_b, proof_c, vk);
         gate_count.print();
-        assert!(result.borrow().get_value());
+        assert!(result.get_value());
     }
 
     #[test]
@@ -264,6 +265,6 @@ mod tests {
         let (result, gate_count) =
             groth16_verifier_evaluate_montgomery(public, proof_a, proof_b, proof_c, vk);
         gate_count.print();
-        assert!(result.borrow().get_value());
+        assert!(result.get_value());
     }
 }

--- a/src/core/bristol.rs
+++ b/src/core/bristol.rs
@@ -1,4 +1,5 @@
 use crate::bag::*;
+use crate::core::wire::with_arena;
 use std::fs;
 
 pub fn parser(filename: &str) -> (Circuit, Vec<Wires>, Vec<Wires>) {
@@ -92,6 +93,7 @@ pub fn parser(filename: &str) -> (Circuit, Vec<Wires>, Vec<Wires>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::wire::{WireOps, with_arena};
     use rand::{Rng, rng};
 
     #[test]
@@ -100,17 +102,17 @@ mod tests {
         let a: u64 = rng().random();
         let b: u64 = rng().random();
         for (i, wire) in inputs[0].iter().enumerate() {
-            wire.borrow_mut().set((a >> i) & 1 == 1);
+            with_arena(|wires| wires[*wire].set((a >> i) & 1 == 1));
         }
         for (i, wire) in inputs[1].iter().enumerate() {
-            wire.borrow_mut().set((b >> i) & 1 == 1);
+            with_arena(|wires| wires[*wire].set((b >> i) & 1 == 1));
         }
         for mut gate in circuit.1 {
             gate.evaluate();
         }
         let mut result_bits = Vec::new();
         for wire in outputs[0].clone() {
-            result_bits.push(wire.borrow().get_value());
+            result_bits.push(with_arena(|wires| wires[wire].get_value()));
         }
         let mut c: u64 = 0;
         for bit in result_bits.iter().rev() {
@@ -125,17 +127,17 @@ mod tests {
         let a: u64 = rng().random();
         let b: u64 = rng().random();
         for (i, wire) in inputs[0].iter().enumerate() {
-            wire.borrow_mut().set((a >> i) & 1 == 1);
+            with_arena(|wires| wires[*wire].set((a >> i) & 1 == 1));
         }
         for (i, wire) in inputs[1].iter().enumerate() {
-            wire.borrow_mut().set((b >> i) & 1 == 1);
+            with_arena(|wires| wires[*wire].set((b >> i) & 1 == 1));
         }
         for mut gate in circuit.1 {
             gate.evaluate();
         }
         let mut result_bits = Vec::new();
         for wire in outputs[0].clone() {
-            result_bits.push(wire.borrow().get_value());
+            result_bits.push(with_arena(|wires| wires[wire].get_value()));
         }
         let mut c: u64 = 0;
         for bit in result_bits.iter().rev() {
@@ -150,17 +152,17 @@ mod tests {
         let a: u64 = rng().random();
         let b: u64 = rng().random();
         for (i, wire) in inputs[0].iter().enumerate() {
-            wire.borrow_mut().set((a >> i) & 1 == 1);
+            with_arena(|wires| wires[*wire].set((a >> i) & 1 == 1));
         }
         for (i, wire) in inputs[1].iter().enumerate() {
-            wire.borrow_mut().set((b >> i) & 1 == 1);
+            with_arena(|wires| wires[*wire].set((b >> i) & 1 == 1));
         }
         for mut gate in circuit.1 {
             gate.evaluate();
         }
         let mut result_bits = Vec::new();
         for wire in outputs[0].clone() {
-            result_bits.push(wire.borrow().get_value());
+            result_bits.push(with_arena(|wires| wires[wire].get_value()));
         }
         let mut c: u64 = 0;
         for bit in result_bits.iter().rev() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,9 @@ pub mod core;
 
 pub mod bag {
     pub use crate::core::circuit::Circuit;
-    pub use crate::core::gate::Gate;
+    pub use crate::core::gate::{Gate, GateCount};
     pub use crate::core::s::S;
-    pub use crate::core::wire::Wire;
-    pub use std::{cell::RefCell, rc::Rc};
-    pub type Wirex = Rc<RefCell<Wire>>;
+    pub use crate::core::wire::{Wire, WireId, new_wirex};
+    pub type Wirex = WireId;
     pub type Wires = Vec<Wirex>;
-    pub use crate::core::gate::GateCount;
-    pub fn new_wirex() -> Wirex {
-        Rc::new(RefCell::new(Wire::new()))
-    }
 }


### PR DESCRIPTION
## Summary
- remove Rc<RefCell> indirection by introducing a global wire arena
- add `WireOps` trait for convenient wire access via indices
- update circuits and tests to use new trait

## Testing
- `cargo fmt`
- `cargo test --quiet` *(timed out during long-running tests)*

------
https://chatgpt.com/codex/tasks/task_e_6865baf9c2108326b7c6a6c6089073fb