### PR TITLE
Automate gate count badge publishing

### DIFF
--- a/.github/workflows/gate-count-badges.yml
+++ b/.github/workflows/gate-count-badges.yml
@@ -67,5 +67,13 @@ jobs:
       with:
         name: gate-counts
         path: |
-          gates.json
-          badge_data/
+          gates.json          badge_data/
+
+    - name: Deploy badge JSONs to gh-badges branch
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./badge_data
+        publish_branch: gh-badges
+        destination_dir: badge_data

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+badge_data/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ## Gate Count Metrics
 
-> **Note:** Gate counts are measured for k=6 (64 constraints) test circuits and can be viewed in the latest CI run artifacts.
+Gate counts are automatically measured for k=6 (64 constraints) on every push to `main` and published as dynamic badges.
+
+![Total Gates](https://img.shields.io/endpoint?url=https://<user>.github.io/garbled-snark-verifier/badge_data/total.json)
+![AND Gates](https://img.shields.io/endpoint?url=https://<user>.github.io/garbled-snark-verifier/badge_data/and.json)
+![XOR Gates](https://img.shields.io/endpoint?url=https://<user>.github.io/garbled-snark-verifier/badge_data/xor.json)
+![NOT Gates](https://img.shields.io/endpoint?url=https://<user>.github.io/garbled-snark-verifier/badge_data/not.json)
 
 A: operator, B: verifier
 


### PR DESCRIPTION
## Summary
- deploy gate count badge files to `gh-badges` branch via CI
- serve badges through GitHub Pages and link them in README
- ignore badge artifacts in git

## Testing
- `cargo fmt --all`
- `cargo check --workspace --all-targets --all-features`


------
https://chatgpt.com/codex/tasks/task_e_686e205cc3a0832693ae2cb66b127c26