### PR TITLE
Add cut-and-choose protocol

### DIFF
--- a/src/circuit/commitment.rs
+++ b/src/circuit/commitment.rs
@@ -1,4 +1,4 @@
-use crate::EvaluatedWire;
+use crate::{EvaluatedWire, S};
 
 /// Simple commit, to be replaced in the future
 pub type Commit = Vec<u8>;
@@ -12,5 +12,15 @@ pub fn commit(wires: impl Iterator<Item = EvaluatedWire>) -> Commit {
         hasher.update(&[evaluated.value() as u8]);
     });
 
+    hasher.finalize().as_bytes().to_vec()
+}
+
+/// Commit to pairs of garbled wire labels.
+pub fn commit_labels(labels: impl Iterator<Item = (S, S)>) -> Commit {
+    let mut hasher = blake3::Hasher::default();
+    for (l0, l1) in labels {
+        hasher.update(&l0.0);
+        hasher.update(&l1.0);
+    }
     hasher.finalize().as_bytes().to_vec()
 }

--- a/src/circuit/garbling.rs
+++ b/src/circuit/garbling.rs
@@ -204,4 +204,18 @@ impl GarbledCircuit {
             self.garbled_table.clone(),
         ))
     }
+
+    /// Commit to all output wires by hashing both garbled labels.
+    pub fn commit_output_labels(&self) -> crate::circuit::commitment::Commit {
+        use crate::circuit::commitment::commit_labels;
+        let labels = self
+            .structure
+            .output_wires
+            .iter()
+            .map(|id| {
+                let w = self.wires.get(*id).unwrap();
+                (w.label0, w.label1)
+            });
+        commit_labels(labels)
+    }
 }

--- a/src/circuit/garbling.rs
+++ b/src/circuit/garbling.rs
@@ -1,9 +1,9 @@
 use rand::Rng;
 
 use super::{
-    errors::CircuitError, evaluation::EvaluatedCircuit, structure::Circuit, Error, FinalizedCircuit,
+    Error, FinalizedCircuit, errors::CircuitError, evaluation::EvaluatedCircuit, structure::Circuit,
 };
-use crate::{Delta, GarbledWire, GarbledWires, WireId, S};
+use crate::{Delta, GarbledWire, GarbledWires, S, WireId};
 
 type DefaultHasher = blake3::Hasher;
 
@@ -30,7 +30,7 @@ impl Circuit {
             self.gates.len()
         );
 
-        let delta = Delta::generate();
+        let delta = Delta::generate_with(rng);
 
         let mut wires = GarbledWires::new(self.num_wire);
         let mut issue_fn = || GarbledWire::random(rng, &delta);

--- a/src/core/delta.rs
+++ b/src/core/delta.rs
@@ -30,7 +30,12 @@ impl Delta {
     /// This ensures that XOR-ing with delta flips the LSB of the last byte,
     /// enabling safe use of point-and-permute.
     pub fn generate() -> Self {
-        let mut s = rng().random::<[u8; 32]>();
+        let mut rng = rng();
+        Self::generate_with(&mut rng)
+    }
+
+    pub fn generate_with(rng: &mut impl Rng) -> Self {
+        let mut s = rng.r#gen::<[u8; 32]>();
         s[31] |= 1; // set LSB of last byte
         Self(S(s))
     }

--- a/src/cut_and_choose.rs
+++ b/src/cut_and_choose.rs
@@ -1,0 +1,179 @@
+use rand::prelude::SliceRandom;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use std::sync::mpsc::{self, Receiver, Sender};
+
+use crate::{Circuit, FinalizedCircuit};
+
+/// Seeds for circuits that were not opened by Bob.
+/// These will be used in the evaluation step (not implemented yet).
+#[derive(Debug, Clone)]
+pub struct EvalSeed {
+    pub index: usize,
+    pub seed: [u8; 32],
+}
+
+enum Message {
+    Commits(Vec<Vec<u8>>),
+    EvalIndices(Vec<usize>),
+    Seeds(Vec<(usize, [u8; 32])>),
+}
+
+fn finalize_commit(gc: &FinalizedCircuit) -> Vec<u8> {
+    gc.output_wires_commit.clone()
+}
+
+fn alice_party(
+    circuit: Circuit,
+    tx: Sender<Message>,
+    rx: Receiver<Message>,
+    total: usize,
+    _eval: usize,
+) -> Result<Vec<EvalSeed>, String> {
+    let mut rng = StdRng::from_os_rng();
+    let mut seeds = Vec::with_capacity(total);
+    let mut commits = Vec::with_capacity(total);
+
+    for _ in 0..total {
+        let seed: [u8; 32] = rng.r#gen();
+        seeds.push(seed);
+        let mut srng = StdRng::from_seed(seed);
+        let garbled = circuit
+            .garble(&mut srng)
+            .map_err(|e| format!("{e:?}"))?;
+        let finalized = garbled
+            .finalize(|_| Some(false))
+            .map_err(|e| format!("{e:?}"))?;
+        commits.push(finalize_commit(&finalized));
+    }
+
+    tx.send(Message::Commits(commits))
+        .map_err(|e| e.to_string())?;
+
+    let eval_indices = match rx.recv().map_err(|e| e.to_string())? {
+        Message::EvalIndices(v) => v,
+        _ => return Err("unexpected message".into()),
+    };
+
+    let seeds_to_send: Vec<(usize, [u8; 32])> = seeds
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|(i, _)| !eval_indices.contains(i))
+        .collect();
+
+    tx.send(Message::Seeds(seeds_to_send))
+        .map_err(|e| e.to_string())?;
+
+    let eval_seeds = seeds
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| eval_indices.contains(i))
+        .map(|(i, s)| EvalSeed { index: i, seed: s })
+        .collect();
+
+    Ok(eval_seeds)
+}
+
+fn bob_party(
+    circuit: Circuit,
+    tx: Sender<Message>,
+    rx: Receiver<Message>,
+    total: usize,
+    eval: usize,
+) -> Result<(), String> {
+    let commits = match rx.recv().map_err(|e| e.to_string())? {
+        Message::Commits(c) => c,
+        _ => return Err("unexpected message".into()),
+    };
+
+    if commits.len() != total {
+        return Err("commit count mismatch".into());
+    }
+
+    let mut rng = StdRng::from_os_rng();
+    let mut eval_indices: Vec<usize> = (0..total).collect();
+    eval_indices.shuffle(&mut rng);
+    eval_indices.truncate(eval);
+    eval_indices.sort_unstable();
+
+    tx.send(Message::EvalIndices(eval_indices.clone()))
+        .map_err(|e| e.to_string())?;
+
+    let seeds = match rx.recv().map_err(|e| e.to_string())? {
+        Message::Seeds(s) => s,
+        _ => return Err("unexpected message".into()),
+    };
+
+    for (i, seed) in seeds {
+        let mut srng = StdRng::from_seed(seed);
+        let garbled = circuit
+            .garble(&mut srng)
+            .map_err(|e| format!("{e:?}"))?;
+        let finalized = garbled
+            .finalize(|_| Some(false))
+            .map_err(|e| format!("{e:?}"))?;
+        if finalize_commit(&finalized) != commits[i] {
+            return Err("commit mismatch".into());
+        }
+    }
+
+    // Evaluation step will use the remaining seeds. Not implemented yet.
+    Ok(())
+}
+
+/// Runs a simple cut-and-choose where Alice generates all circuits and Bob
+/// checks a random subset. Returns the seeds of the unchecked circuits.
+pub fn run_cut_and_choose(
+    alice: Circuit,
+    bob: Circuit,
+    total: usize,
+    eval: usize,
+) -> Result<Vec<EvalSeed>, String> {
+    let (tx_ab, rx_ab) = mpsc::channel();
+    let (tx_ba, rx_ba) = mpsc::channel();
+
+    let alice_handle = std::thread::spawn(move || alice_party(alice, tx_ab, rx_ba, total, eval));
+    let bob_handle = std::thread::spawn(move || bob_party(bob, tx_ba, rx_ab, total, eval));
+
+    let seeds = alice_handle.join().unwrap()?;
+    bob_handle.join().unwrap()?;
+
+    Ok(seeds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Gate, GateType};
+
+    fn simple_circuit() -> Circuit {
+        let mut circuit = Circuit::default();
+        let a = circuit.issue_input_wire();
+        let b = circuit.issue_input_wire();
+        let out = circuit.issue_wire();
+        circuit.add_gate(Gate::new(GateType::Xor, a, b, out));
+        circuit.make_wire_output(out);
+        circuit
+    }
+
+    #[test]
+    fn test_cut_and_choose_success() {
+        let alice = simple_circuit();
+        let bob = simple_circuit();
+        let seeds = run_cut_and_choose(alice, bob, 7, 5).expect("protocol should succeed");
+        assert_eq!(seeds.len(), 5);
+    }
+
+    #[test]
+    fn test_cut_and_choose_mismatch() {
+        let mut alice = simple_circuit();
+        let bob = simple_circuit();
+        let extra = alice.issue_wire();
+        alice.add_gate(Gate::new(GateType::And, extra, extra, extra));
+
+        let res = run_cut_and_choose(alice, bob, 7, 5);
+        assert!(res.is_err());
+    }
+}
+

--- a/src/cut_and_choose.rs
+++ b/src/cut_and_choose.rs
@@ -3,9 +3,9 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use std::sync::mpsc::{self, Receiver, Sender};
 
-use crate::{Circuit, FinalizedCircuit};
+use crate::Circuit;
 
-/// Seeds for circuits that were not opened by Bob.
+/// Seeds for circuits that were not opened by the evaluator.
 /// These will be used in the evaluation step (not implemented yet).
 #[derive(Debug, Clone)]
 pub struct EvalSeed {
@@ -19,34 +19,34 @@ enum Message {
     Seeds(Vec<(usize, [u8; 32])>),
 }
 
-fn finalize_commit(gc: &FinalizedCircuit) -> Vec<u8> {
-    gc.output_wires_commit.clone()
-}
+const GARBLER: &str = "[garbler]";
+const EVALUATOR: &str = "[evaluator]";
 
-fn alice_party(
+fn garbler_party(
     circuit: Circuit,
     tx: Sender<Message>,
     rx: Receiver<Message>,
     total: usize,
     _eval: usize,
 ) -> Result<Vec<EvalSeed>, String> {
+    log::info!("{GARBLER} generating {total} circuits");
     let mut rng = StdRng::from_os_rng();
     let mut seeds = Vec::with_capacity(total);
     let mut commits = Vec::with_capacity(total);
 
-    for _ in 0..total {
+    for i in 0..total {
         let seed: [u8; 32] = rng.r#gen();
         seeds.push(seed);
         let mut srng = StdRng::from_seed(seed);
         let garbled = circuit
             .garble(&mut srng)
             .map_err(|e| format!("{e:?}"))?;
-        let finalized = garbled
-            .finalize(|_| Some(false))
-            .map_err(|e| format!("{e:?}"))?;
-        commits.push(finalize_commit(&finalized));
+        let commit = garbled.commit_output_labels();
+        log::debug!("{GARBLER} circuit {i} commit={:?}", commit);
+        commits.push(commit);
     }
 
+    log::info!("{GARBLER} sending commits");
     tx.send(Message::Commits(commits))
         .map_err(|e| e.to_string())?;
 
@@ -54,6 +54,7 @@ fn alice_party(
         Message::EvalIndices(v) => v,
         _ => return Err("unexpected message".into()),
     };
+    log::info!("{GARBLER} evaluator chose indices {eval_indices:?}");
 
     let seeds_to_send: Vec<(usize, [u8; 32])> = seeds
         .iter()
@@ -62,6 +63,7 @@ fn alice_party(
         .filter(|(i, _)| !eval_indices.contains(i))
         .collect();
 
+    log::info!("{GARBLER} sending {} seeds", seeds_to_send.len());
     tx.send(Message::Seeds(seeds_to_send))
         .map_err(|e| e.to_string())?;
 
@@ -75,17 +77,19 @@ fn alice_party(
     Ok(eval_seeds)
 }
 
-fn bob_party(
+fn evaluator_party(
     circuit: Circuit,
     tx: Sender<Message>,
     rx: Receiver<Message>,
     total: usize,
     eval: usize,
 ) -> Result<(), String> {
+    log::info!("{EVALUATOR} waiting for commits");
     let commits = match rx.recv().map_err(|e| e.to_string())? {
         Message::Commits(c) => c,
         _ => return Err("unexpected message".into()),
     };
+    log::info!("{EVALUATOR} received {} commits", commits.len());
 
     if commits.len() != total {
         return Err("commit count mismatch".into());
@@ -96,6 +100,7 @@ fn bob_party(
     eval_indices.shuffle(&mut rng);
     eval_indices.truncate(eval);
     eval_indices.sort_unstable();
+    log::info!("{EVALUATOR} checking indices {eval_indices:?}");
 
     tx.send(Message::EvalIndices(eval_indices.clone()))
         .map_err(|e| e.to_string())?;
@@ -104,16 +109,15 @@ fn bob_party(
         Message::Seeds(s) => s,
         _ => return Err("unexpected message".into()),
     };
+    log::info!("{EVALUATOR} received {} seeds", seeds.len());
 
     for (i, seed) in seeds {
         let mut srng = StdRng::from_seed(seed);
         let garbled = circuit
             .garble(&mut srng)
             .map_err(|e| format!("{e:?}"))?;
-        let finalized = garbled
-            .finalize(|_| Some(false))
-            .map_err(|e| format!("{e:?}"))?;
-        if finalize_commit(&finalized) != commits[i] {
+        let commit = garbled.commit_output_labels();
+        if commit != commits[i] {
             return Err("commit mismatch".into());
         }
     }
@@ -122,22 +126,23 @@ fn bob_party(
     Ok(())
 }
 
-/// Runs a simple cut-and-choose where Alice generates all circuits and Bob
-/// checks a random subset. Returns the seeds of the unchecked circuits.
+/// Runs a simple cut-and-choose where the garbler generates all circuits and
+/// the evaluator checks a random subset. Returns the seeds of the unchecked
+/// circuits.
 pub fn run_cut_and_choose(
-    alice: Circuit,
-    bob: Circuit,
+    garbler: Circuit,
+    evaluator: Circuit,
     total: usize,
     eval: usize,
 ) -> Result<Vec<EvalSeed>, String> {
     let (tx_ab, rx_ab) = mpsc::channel();
     let (tx_ba, rx_ba) = mpsc::channel();
 
-    let alice_handle = std::thread::spawn(move || alice_party(alice, tx_ab, rx_ba, total, eval));
-    let bob_handle = std::thread::spawn(move || bob_party(bob, tx_ba, rx_ab, total, eval));
+    let garbler_handle = std::thread::spawn(move || garbler_party(garbler, tx_ab, rx_ba, total, eval));
+    let evaluator_handle = std::thread::spawn(move || evaluator_party(evaluator, tx_ba, rx_ab, total, eval));
 
-    let seeds = alice_handle.join().unwrap()?;
-    bob_handle.join().unwrap()?;
+    let seeds = garbler_handle.join().unwrap()?;
+    evaluator_handle.join().unwrap()?;
 
     Ok(seeds)
 }
@@ -159,20 +164,20 @@ mod tests {
 
     #[test]
     fn test_cut_and_choose_success() {
-        let alice = simple_circuit();
-        let bob = simple_circuit();
-        let seeds = run_cut_and_choose(alice, bob, 7, 5).expect("protocol should succeed");
+        let garbler = simple_circuit();
+        let evaluator = simple_circuit();
+        let seeds = run_cut_and_choose(garbler, evaluator, 7, 5).expect("protocol should succeed");
         assert_eq!(seeds.len(), 5);
     }
 
     #[test]
     fn test_cut_and_choose_mismatch() {
-        let mut alice = simple_circuit();
-        let bob = simple_circuit();
-        let extra = alice.issue_wire();
-        alice.add_gate(Gate::new(GateType::And, extra, extra, extra));
+        let mut garbler = simple_circuit();
+        let evaluator = simple_circuit();
+        let extra = garbler.issue_wire();
+        garbler.add_gate(Gate::new(GateType::And, extra, extra, extra));
 
-        let res = run_cut_and_choose(alice, bob, 7, 5);
+        let res = run_cut_and_choose(garbler, evaluator, 7, 5);
         assert!(res.is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod circuit;
 mod core;
+mod cut_and_choose;
 mod gadgets;
 mod math;
 
@@ -12,6 +13,7 @@ pub use core::{
 };
 
 pub use circuit::{Circuit, CircuitError, EvaluatedCircuit, FinalizedCircuit, GarbledCircuit};
+pub use cut_and_choose::{run_cut_and_choose, EvalSeed};
 pub use math::*;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- implement simplified one-way cut-and-choose
- expose cut-and-choose API
- add tests for honest and mismatching cases

## Testing
- `cargo test cut_and_choose --quiet`
- `cargo test --quiet` *(fails: test_fq_inverse, test_fq_inverse_montgomery)*


------
https://chatgpt.com/codex/tasks/task_e_6881d8ba58f88326b477f2627b10c3b7