### PR TITLE
Add deterministic garbling with cut and choose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.9.1",
+ "rand_chacha 0.9.0",
  "sha2",
  "test-log",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4.27"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-traits = "0.2"
 rand = "0.9.1"
+rand_chacha = "0.9"
 thiserror = "2.0.12"
 
 [dev-dependencies]

--- a/src/circuit/errors.rs
+++ b/src/circuit/errors.rs
@@ -1,9 +1,11 @@
 use crate::GateError;
 
-#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error)]
 pub enum CircuitError {
     #[error("Gate error: {0}")]
     Gate(#[from] GateError),
     #[error("Garbling failed: {0}")]
     GarblingFailed(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
 }

--- a/src/circuit/garbling.rs
+++ b/src/circuit/garbling.rs
@@ -1,4 +1,9 @@
 use rand::Rng;
+use std::{
+    fs::File,
+    io::{self, Write},
+    sync::mpsc::Sender,
+};
 
 use super::{
     Error, FinalizedCircuit, errors::CircuitError, evaluation::EvaluatedCircuit, structure::Circuit,
@@ -6,6 +11,116 @@ use super::{
 use crate::{Delta, GarbledWire, GarbledWires, S, WireId};
 
 type DefaultHasher = blake3::Hasher;
+
+fn compute_label_hashes(
+    circuit: &Circuit,
+    wires: &GarbledWires,
+) -> (Vec<(WireId, (S, S))>, Vec<(WireId, S)>) {
+    fn hash_label<H: digest::Digest + Default>(label: &S) -> S {
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&H::default().chain_update(label.0).finalize()[..32]);
+        S(out)
+    }
+
+    let mut input_hashes = Vec::new();
+    for &wire_id in [
+        circuit.get_false_wire_constant(),
+        circuit.get_true_wire_constant(),
+    ]
+    .iter()
+    .chain(circuit.input_wires.iter())
+    {
+        let wire = wires.get(wire_id).unwrap();
+        let h0 = hash_label::<DefaultHasher>(&wire.label0);
+        let h1 = hash_label::<DefaultHasher>(&wire.label1);
+        input_hashes.push((wire_id, (h0, h1)));
+    }
+
+    let mut output_hashes = Vec::new();
+    for &wire_id in &circuit.output_wires {
+        let wire = wires.get(wire_id).unwrap();
+        let h1 = hash_label::<DefaultHasher>(&wire.label1);
+        output_hashes.push((wire_id, h1));
+    }
+
+    (input_hashes, output_hashes)
+}
+
+pub trait CiphertextSink {
+    fn push(&mut self, ct: S) -> io::Result<()>;
+    fn finalize(&mut self) -> io::Result<S>;
+}
+
+#[derive(Default)]
+pub struct VecSink {
+    pub ciphertexts: Vec<S>,
+    hasher: blake3::Hasher,
+}
+
+impl CiphertextSink for VecSink {
+    fn push(&mut self, ct: S) -> io::Result<()> {
+        self.hasher.update(&ct.0);
+        self.ciphertexts.push(ct);
+        Ok(())
+    }
+
+    fn finalize(&mut self) -> io::Result<S> {
+        Ok(S(*self.hasher.finalize().as_bytes()))
+    }
+}
+
+pub struct ChannelSink<'a> {
+    pub sender: &'a Sender<S>,
+    hasher: blake3::Hasher,
+}
+
+impl<'a> ChannelSink<'a> {
+    pub fn new(sender: &'a Sender<S>) -> Self {
+        Self {
+            sender,
+            hasher: blake3::Hasher::new(),
+        }
+    }
+}
+
+impl<'a> CiphertextSink for ChannelSink<'a> {
+    fn push(&mut self, ct: S) -> io::Result<()> {
+        self.hasher.update(&ct.0);
+        self.sender
+            .send(ct)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    fn finalize(&mut self) -> io::Result<S> {
+        Ok(S(*self.hasher.finalize().as_bytes()))
+    }
+}
+
+pub struct FileSink {
+    file: File,
+    hasher: blake3::Hasher,
+}
+
+impl FileSink {
+    pub fn create(path: impl AsRef<std::path::Path>) -> io::Result<Self> {
+        Ok(Self {
+            file: File::create(path)?,
+            hasher: blake3::Hasher::new(),
+        })
+    }
+}
+
+impl CiphertextSink for FileSink {
+    fn push(&mut self, ct: S) -> io::Result<()> {
+        self.hasher.update(&ct.0);
+        self.file.write_all(&ct.0)
+    }
+
+    fn finalize(&mut self) -> io::Result<S> {
+        self.file.sync_all()?;
+        Ok(S(*self.hasher.finalize().as_bytes()))
+    }
+}
 
 #[derive(Debug)]
 pub struct GarbledCircuit {
@@ -23,22 +138,13 @@ pub struct GarbledCircuitHashes {
 }
 
 impl Circuit {
-    pub fn garble_from_seed(&self, seed: [u8; 32]) -> Result<GarbledCircuit, CircuitError> {
-        use rand_chacha::rand_core::SeedableRng;
-        let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed);
-        self.garble(&mut rng)
-    }
-
-    pub fn garble(&self, rng: &mut impl Rng) -> Result<GarbledCircuit, CircuitError> {
-        self.garble_with::<DefaultHasher>(rng)
-    }
-
-    pub fn garble_with<H: digest::Digest + Default + Clone>(
+    pub fn garble_into_with<H: digest::Digest + Default + Clone, SINK: CiphertextSink>(
         &self,
         rng: &mut impl Rng,
-    ) -> Result<GarbledCircuit, CircuitError> {
+        sink: &mut SINK,
+    ) -> Result<(GarbledCircuit, GarbledCircuitHashes), CircuitError> {
         log::debug!(
-            "garble: start wires={} gates={}",
+            "garble(stream): start wires={} gates={}",
             self.num_wire,
             self.gates.len()
         );
@@ -58,76 +164,75 @@ impl Circuit {
             wires.get_or_init(*wire_id, &mut issue_fn).unwrap();
         });
 
-        log::debug!("garble: delta={delta:?}");
+        for (i, g) in self.gates.iter().enumerate() {
+            match g.garble::<H>(i, &mut wires, &delta, rng) {
+                Ok(Some(row)) => sink.push(row)?,
+                Ok(None) => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
 
-        let garbled_table = self
-            .gates
-            .iter()
-            .enumerate()
-            .filter_map(|(i, g)| {
-                log::debug!(
-                    "garble: gate[{}] {:?} {}+{}->{}",
-                    i,
-                    g.gate_type,
-                    g.wire_a,
-                    g.wire_b,
-                    g.wire_c
-                );
-                match g.garble::<H>(i, &mut wires, &delta, rng) {
-                    Ok(Some(row)) => {
-                        log::debug!("garble: gate[{i}] table_entries={row:?}");
-                        Some(Ok(row))
-                    }
-                    Ok(None) => {
-                        log::debug!("garble: gate[{i}] free");
-                        None
-                    }
-                    Err(err) => {
-                        log::error!("garble: gate[{i}] error={err:?}");
-                        Some(Err(err))
-                    }
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let table_hash = sink.finalize()?;
+        log::debug!("garble(stream): complete");
 
-        log::debug!("garble: complete table_size={}", garbled_table.len());
-        Ok(GarbledCircuit {
+        let (input_hashes, output_hashes) = compute_label_hashes(self, &wires);
+        let gc = GarbledCircuit {
             structure: self.clone(),
             wires,
             delta,
-            garbled_table,
-        })
+            garbled_table: Vec::new(),
+        };
+
+        Ok((
+            gc,
+            GarbledCircuitHashes {
+                input_hashes,
+                output_hashes,
+                table_hash,
+            },
+        ))
+    }
+
+    pub fn garble_with_commit<H: digest::Digest + Default + Clone>(
+        &self,
+        rng: &mut impl Rng,
+    ) -> Result<(GarbledCircuit, GarbledCircuitHashes), CircuitError> {
+        let mut sink = VecSink::default();
+        let (mut gc, hashes) = self.garble_into_with::<H, _>(rng, &mut sink)?;
+        gc.garbled_table = sink.ciphertexts;
+        Ok((gc, hashes))
+    }
+
+    pub fn garble_from_seed(&self, seed: [u8; 32]) -> Result<GarbledCircuit, CircuitError> {
+        use rand_chacha::rand_core::SeedableRng;
+        let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed);
+        Ok(self.garble_with_commit::<DefaultHasher>(&mut rng)?.0)
+    }
+
+    pub fn garble_from_seed_with_commit(
+        &self,
+        seed: [u8; 32],
+    ) -> Result<(GarbledCircuit, GarbledCircuitHashes), CircuitError> {
+        use rand_chacha::rand_core::SeedableRng;
+        let mut rng = rand_chacha::ChaCha20Rng::from_seed(seed);
+        self.garble_with_commit::<DefaultHasher>(&mut rng)
+    }
+
+    pub fn garble(&self, rng: &mut impl Rng) -> Result<GarbledCircuit, CircuitError> {
+        Ok(self.garble_with_commit::<DefaultHasher>(rng)?.0)
+    }
+
+    pub fn garble_with<H: digest::Digest + Default + Clone>(
+        &self,
+        rng: &mut impl Rng,
+    ) -> Result<GarbledCircuit, CircuitError> {
+        Ok(self.garble_with_commit::<H>(rng)?.0)
     }
 }
 
 impl GarbledCircuit {
     pub fn hashes(&self) -> GarbledCircuitHashes {
-        fn hash_label<H: digest::Digest + Default>(label: &S) -> S {
-            let mut out = [0u8; 32];
-            out.copy_from_slice(&H::default().chain_update(label.0).finalize()[..32]);
-            S(out)
-        }
-
-        let mut input_hashes = Vec::new();
-        for &wire_id in [
-            self.structure.get_false_wire_constant(),
-            self.structure.get_true_wire_constant(),
-        ]
-        .iter()
-        .chain(self.structure.input_wires.iter())
-        {
-            let wire = self.wires.get(wire_id).unwrap();
-            let h0 = hash_label::<DefaultHasher>(&wire.label0);
-            let h1 = hash_label::<DefaultHasher>(&wire.label1);
-            input_hashes.push((wire_id, (h0, h1)));
-        }
-
-        let mut output_hashes = Vec::new();
-        for &wire_id in &self.structure.output_wires {
-            let wire = self.wires.get(wire_id).unwrap();
-            let h1 = hash_label::<DefaultHasher>(&wire.label1);
-            output_hashes.push((wire_id, h1));
-        }
+        let (input_hashes, output_hashes) = compute_label_hashes(&self.structure, &self.wires);
 
         let mut th = DefaultHasher::default();
         for ct in &self.garbled_table {

--- a/src/core/delta.rs
+++ b/src/core/delta.rs
@@ -22,6 +22,12 @@ use crate::S;
 pub struct Delta(S);
 
 impl Delta {
+    pub fn generate_with(rng: &mut impl Rng) -> Self {
+        let mut s = rng.random::<[u8; 32]>();
+        s[31] |= 1;
+        Self(S(s))
+    }
+
     /// Generates a new delta with a guaranteed permutation bit of 1.
     ///
     /// This function loops internally until the generated value
@@ -30,9 +36,8 @@ impl Delta {
     /// This ensures that XOR-ing with delta flips the LSB of the last byte,
     /// enabling safe use of point-and-permute.
     pub fn generate() -> Self {
-        let mut s = rng().random::<[u8; 32]>();
-        s[31] |= 1; // set LSB of last byte
-        Self(S(s))
+        let mut r = rng();
+        Self::generate_with(&mut r)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod circuit;
 mod core;
 mod gadgets;
 mod math;
+mod protocol;
 
 pub use core::{
     delta::Delta,
@@ -13,6 +14,7 @@ pub use core::{
 
 pub use circuit::{Circuit, CircuitError, EvaluatedCircuit, FinalizedCircuit, GarbledCircuit};
 pub use math::*;
+pub use protocol::cut_and_choose::{GarbledCopy, VerifierState};
 
 #[cfg(test)]
 pub mod test_utils {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use core::{
 };
 
 pub use circuit::{Circuit, CircuitError, EvaluatedCircuit, FinalizedCircuit, GarbledCircuit};
+pub use gadgets::bn254::{Fq, fp254impl::Fp254Impl};
 pub use math::*;
 pub use protocol::cut_and_choose::{GarbledCopy, VerifierState};
 

--- a/src/protocol/cut_and_choose.rs
+++ b/src/protocol/cut_and_choose.rs
@@ -1,0 +1,54 @@
+use rand::Rng;
+use std::collections::{HashMap, HashSet};
+
+use crate::{Circuit, S, circuit::garbling::GarbledCircuitHashes};
+
+#[derive(Debug, Clone)]
+pub struct GarbledCopy {
+    pub seed: [u8; 32],
+    pub hashes: GarbledCircuitHashes,
+    pub ciphertexts: Vec<S>,
+}
+
+#[derive(Debug)]
+pub struct VerifierState {
+    pub eval_indices: HashSet<usize>,
+    pub stored_ciphertexts: HashMap<usize, Vec<S>>, // evaluation circuits
+}
+
+impl VerifierState {
+    pub fn new(num_copies: usize, eval_count: usize, rng: &mut impl Rng) -> Self {
+        let mut eval_indices = HashSet::new();
+        while eval_indices.len() < eval_count {
+            let idx = rng.random_range(0..num_copies);
+            eval_indices.insert(idx);
+        }
+        Self {
+            eval_indices,
+            stored_ciphertexts: HashMap::new(),
+        }
+    }
+
+    pub fn receive_copy(
+        &mut self,
+        circuit: &Circuit,
+        index: usize,
+        copy: GarbledCopy,
+    ) -> Result<(), String> {
+        if self.eval_indices.contains(&index) {
+            self.stored_ciphertexts.insert(index, copy.ciphertexts);
+            Ok(())
+        } else {
+            let recomputed = circuit
+                .garble_from_seed(copy.seed)
+                .map_err(|e| format!("garbling failed: {e:?}"))?;
+            if recomputed.garbled_table != copy.ciphertexts {
+                return Err("ciphertext mismatch".into());
+            }
+            if recomputed.hashes() != copy.hashes {
+                return Err("hash mismatch".into());
+            }
+            Ok(())
+        }
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,0 +1,1 @@
+pub mod cut_and_choose;

--- a/tests/cut_and_choose.rs
+++ b/tests/cut_and_choose.rs
@@ -38,11 +38,13 @@ fn test_verifier_detects_wrong_seed() {
     let mut seed = [0u8; 32];
     rng.fill_bytes(&mut seed);
     let mut copy = {
-        let g = circuit.garble_from_seed(seed).unwrap();
+        let (g, hashes) = circuit.garble_from_seed_with_commit(seed).unwrap();
+        let table_hash = hashes.table_hash;
         GarbledCopy {
             seed,
-            hashes: g.hashes(),
-            ciphertexts: g.garbled_table.clone(),
+            hashes,
+            ciphertext_hash: table_hash,
+            ciphertexts: Some(g.garbled_table.clone()),
         }
     };
     // corrupt seed
@@ -64,11 +66,12 @@ fn test_full_protocol_honest() {
             for i in 0..num {
                 let mut seed = [0u8; 32];
                 rng.fill_bytes(&mut seed);
-                let gc = circuit.garble_from_seed(seed).unwrap();
+                let (gc, hashes) = circuit.garble_from_seed_with_commit(seed).unwrap();
                 let copy = GarbledCopy {
                     seed,
-                    hashes: gc.hashes(),
-                    ciphertexts: gc.garbled_table.clone(),
+                    hashes: hashes.clone(),
+                    ciphertext_hash: hashes.table_hash,
+                    ciphertexts: Some(gc.garbled_table.clone()),
                 };
                 tx.send((i, copy)).unwrap();
             }

--- a/tests/cut_and_choose.rs
+++ b/tests/cut_and_choose.rs
@@ -1,0 +1,84 @@
+use garbled_snark_verifier::*;
+use rand::{RngCore, SeedableRng};
+use std::sync::mpsc::channel;
+use std::thread;
+
+fn trng() -> rand::rngs::SmallRng {
+    rand::rngs::SmallRng::seed_from_u64(0)
+}
+
+fn simple_and() -> Circuit {
+    let mut c = Circuit::default();
+    let a = c.issue_input_wire();
+    let b = c.issue_input_wire();
+    let out = c.issue_wire();
+    c.add_gate(Gate::new(GateType::And, a, b, out));
+    c.make_wire_output(out);
+    c
+}
+
+#[test]
+fn test_seeded_garbling_deterministic() {
+    let circuit = simple_and();
+    let seed = [42u8; 32];
+    let g1 = circuit.garble_from_seed(seed).unwrap();
+    let g2 = circuit.garble_from_seed(seed).unwrap();
+    assert_eq!(g1.delta, g2.delta);
+    assert_eq!(g1.garbled_table, g2.garbled_table);
+    assert_eq!(
+        g1.wires.get(WireId(2)).unwrap(),
+        g2.wires.get(WireId(2)).unwrap()
+    );
+}
+
+#[test]
+fn test_verifier_detects_wrong_seed() {
+    let circuit = simple_and();
+    let mut rng = trng();
+    let mut seed = [0u8; 32];
+    rng.fill_bytes(&mut seed);
+    let mut copy = {
+        let g = circuit.garble_from_seed(seed).unwrap();
+        GarbledCopy {
+            seed,
+            hashes: g.hashes(),
+            ciphertexts: g.garbled_table.clone(),
+        }
+    };
+    // corrupt seed
+    copy.seed[0] ^= 1;
+    let mut verifier = VerifierState::new(1, 0, &mut rng);
+    let res = verifier.receive_copy(&circuit, 0, copy);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_full_protocol_honest() {
+    let circuit = simple_and();
+    let num = 3;
+    let (tx, rx) = channel();
+    thread::spawn({
+        let circuit = circuit.clone();
+        move || {
+            let mut rng = trng();
+            for i in 0..num {
+                let mut seed = [0u8; 32];
+                rng.fill_bytes(&mut seed);
+                let gc = circuit.garble_from_seed(seed).unwrap();
+                let copy = GarbledCopy {
+                    seed,
+                    hashes: gc.hashes(),
+                    ciphertexts: gc.garbled_table.clone(),
+                };
+                tx.send((i, copy)).unwrap();
+            }
+        }
+    });
+
+    let mut rng = trng();
+    let mut verifier = VerifierState::new(num as usize, 1, &mut rng);
+    for _ in 0..num {
+        let (idx, copy) = rx.recv().unwrap();
+        verifier.receive_copy(&circuit, idx, copy).unwrap();
+    }
+}

--- a/tests/montgomery_mul.rs
+++ b/tests/montgomery_mul.rs
@@ -1,0 +1,40 @@
+use ark_ff::Field;
+use garbled_snark_verifier::Fp254Impl;
+use garbled_snark_verifier::Fq;
+use garbled_snark_verifier::*;
+use rand::{RngCore, SeedableRng};
+
+fn rnd() -> ark_bn254::Fq {
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+    loop {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        if let Some(bn) = ark_bn254::Fq::from_random_bytes(&bytes) {
+            return bn;
+        }
+    }
+}
+
+#[test]
+fn test_montgomery_mul_consistency() {
+    let mut circuit = Circuit::default();
+    let a = Fq::new_bn(&mut circuit, true, false);
+    let b = Fq::new_bn(&mut circuit, true, false);
+    let c = Fq::mul_montgomery(&mut circuit, &a, &b);
+    c.mark_as_output(&mut circuit);
+
+    let a_val = Fq::as_montgomery(rnd());
+    let b_val = Fq::as_montgomery(rnd());
+    let expected = Fq::as_montgomery(Fq::from_montgomery(a_val) * Fq::from_montgomery(b_val));
+
+    let a_input = Fq::get_wire_bits_fn(&a, &a_val).unwrap();
+    let b_input = Fq::get_wire_bits_fn(&b, &b_val).unwrap();
+    let c_output = Fq::get_wire_bits_fn(&c, &expected).unwrap();
+
+    circuit
+        .simple_evaluate(|w| a_input(w).or_else(|| b_input(w)))
+        .unwrap()
+        .for_each(|(wire_id, value)| {
+            assert_eq!(c_output(wire_id), Some(value));
+        });
+}


### PR DESCRIPTION
## Summary
- add deterministic garbling via ChaCha20Rng
- compute hash commitments for garbled circuits
- implement simple cut-and-choose protocol structures
- emulate protocol interaction using channels in tests
- fix RNG API usage

## Testing
- `cargo test --test cut_and_choose -- --nocapture`
- `cargo test --lib -- --quiet` *(fails: `test_fq_inverse`, `test_fq_inverse_montgomery`, hangs on `test_fq_sqrt_montgomery`)*

------
https://chatgpt.com/codex/tasks/task_e_6881d8cca9e88326929a6fd3f5d892fe