### PR TITLE
Write gate count to serialization file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +841,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tempfile",
 ]
 
 [[package]]
@@ -949,6 +966,12 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -1247,6 +1270,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1515,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ ark-crypto-primitives = "0.5.0"
 ark-relations = "0.5.0"
 serial_test = "3.2.0"
 once_cell = "1.21.3"
+
+[dev-dependencies]
+tempfile = "3.10.1"
+

--- a/README.md
+++ b/README.md
@@ -59,3 +59,25 @@ this folder contains all the circuit functions. At the end, it will contain the 
 **bigint**: contains u254 circuits
 
 **bn254**: contains circuits related to bn254 curve such as field arithmetic circuits etc.
+
+### Gate Serialization Format
+
+The helper module `src/core/serialization.rs` allows dumping large
+Groth16 circuits directly to disk. A binary file is written in the
+following layout so that the whole circuit does not have to reside in
+memory:
+
+- **Header** – 4 bytes ASCII `GTV1` written once when the file is
+  created.
+- **Gate count** – 8 bytes little endian `u64` giving the total number of
+  gate records stored in the file.
+- **Gate records** – repeated for every gate in topological order:
+  - 1 byte: operation (`GateType` as `u8`)
+  - 5 bytes: little endian ID of `wire_a`
+  - 5 bytes: little endian ID of `wire_b`
+  - 5 bytes: little endian ID of `wire_c`
+
+The fixed 5‑byte encoding efficiently covers `Wire.id` values up to
+`11_000_000_000`. New gates can be appended to an existing file with
+`append_gates`; the routine updates the stored gate count and then
+appends the new records without rewriting earlier data.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,3 +4,4 @@ pub mod gate;
 pub mod s;
 pub mod utils;
 pub mod wire;
+pub mod serialization;

--- a/src/core/serialization.rs
+++ b/src/core/serialization.rs
@@ -1,0 +1,152 @@
+use std::fs::OpenOptions;
+use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+use crate::bag::Gate;
+
+/// Magic header written to serialized gate files.
+pub const FILE_MAGIC: &[u8; 4] = b"GTV1";
+
+/// Helper struct returned when reading a serialized gate file.
+#[derive(Debug, PartialEq, Eq)]
+pub struct GateRecord {
+    pub operation: u8,
+    pub wire_a: u64,
+    pub wire_b: u64,
+    pub wire_c: u64,
+}
+
+fn write_id<W: Write>(mut writer: W, id: u64) -> io::Result<()> {
+    assert!(id <= 0xFFFF_FFFF_FFu64);
+    let bytes = id.to_le_bytes();
+    writer.write_all(&bytes[..5])
+}
+
+fn read_id<R: Read>(mut reader: R) -> io::Result<u64> {
+    let mut buf = [0u8; 8];
+    reader.read_exact(&mut buf[..5])?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+fn open_writer<P: AsRef<Path>>(path: P, append: bool) -> io::Result<BufWriter<std::fs::File>> {
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .append(append)
+        .truncate(!append)
+        .open(path)?;
+    Ok(BufWriter::new(file))
+}
+
+/// Write gates to the given file, overwriting existing content.
+pub fn write_gates<P: AsRef<Path>>(gates: &[Gate], path: P) -> io::Result<()> {
+    let mut writer = open_writer(path, false)?;
+    writer.write_all(FILE_MAGIC)?;
+    writer.write_all(&(gates.len() as u64).to_le_bytes())?;
+    for gate in gates {
+        serialize_gate(&mut writer, gate)?;
+    }
+    writer.flush()
+}
+
+/// Append gates to an existing file.
+pub fn append_gates<P: AsRef<Path>>(gates: &[Gate], path: P) -> io::Result<()> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(path)?;
+
+    if file.metadata()?.len() == 0 {
+        file.write_all(FILE_MAGIC)?;
+        file.write_all(&0u64.to_le_bytes())?;
+    }
+
+    file.seek(SeekFrom::Start(0))?;
+    let mut magic = [0u8; 4];
+    file.read_exact(&mut magic)?;
+    if &magic != FILE_MAGIC {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "bad magic"));
+    }
+
+    let mut count_bytes = [0u8; 8];
+    file.read_exact(&mut count_bytes)?;
+    let mut count = u64::from_le_bytes(count_bytes);
+    count += gates.len() as u64;
+
+    file.seek(SeekFrom::Start(FILE_MAGIC.len() as u64))?;
+    file.write_all(&count.to_le_bytes())?;
+    file.seek(SeekFrom::End(0))?;
+    let mut writer = BufWriter::new(file);
+    for gate in gates {
+        serialize_gate(&mut writer, gate)?;
+    }
+    writer.flush()
+}
+
+fn serialize_gate<W: Write>(writer: &mut W, gate: &Gate) -> io::Result<()> {
+    writer.write_all(&[gate.gate_type as u8])?;
+    write_id(&mut *writer, gate.wire_a.borrow().id)?;
+    write_id(&mut *writer, gate.wire_b.borrow().id)?;
+    write_id(writer, gate.wire_c.borrow().id)
+}
+
+/// Read all gates from a serialized file.
+pub fn read_gates<P: AsRef<Path>>(path: P) -> io::Result<Vec<GateRecord>> {
+    let mut file = std::fs::File::open(path)?;
+    let mut magic = [0u8; 4];
+    file.read_exact(&mut magic)?;
+    if &magic != FILE_MAGIC {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "bad magic"));
+    }
+    let mut count_bytes = [0u8; 8];
+    file.read_exact(&mut count_bytes)?;
+    let count = u64::from_le_bytes(count_bytes);
+    let mut gates = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let mut op = [0u8; 1];
+        file.read_exact(&mut op)?;
+        let a = read_id(&mut file)?;
+        let b = read_id(&mut file)?;
+        let c = read_id(&mut file)?;
+        gates.push(GateRecord {
+            operation: op[0],
+            wire_a: a,
+            wire_b: b,
+            wire_c: c,
+        });
+    }
+    Ok(gates)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuits::bn254::fp254impl::Fp254Impl;
+    use crate::circuits::bn254::fq::Fq;
+
+    #[test]
+    fn test_gate_serialization() {
+        let a = Fq::random();
+        let b = Fq::random();
+        let circuit = Fq::mul_montgomery(
+            Fq::wires_set(Fq::as_montgomery(a)),
+            Fq::wires_set(Fq::as_montgomery(b)),
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gates.bin");
+        write_gates(&circuit.1, &path).unwrap();
+        let records = read_gates(&path).unwrap();
+        assert_eq!(records.len(), circuit.1.len());
+        assert_eq!(records[0].operation, circuit.1[0].gate_type as u8);
+
+        append_gates(&circuit.1, &path).unwrap();
+        let records = read_gates(&path).unwrap();
+        assert_eq!(records.len(), circuit.1.len() * 2);
+        assert_eq!(
+            records[circuit.1.len()].operation,
+            circuit.1[0].gate_type as u8
+        );
+    }
+}

--- a/src/core/wire.rs
+++ b/src/core/wire.rs
@@ -1,9 +1,14 @@
 use crate::core::s::S;
-use crate::core::utils::{LIMB_LEN, N_LIMBS, convert_between_blake3_and_normal_form};
+use crate::core::utils::{convert_between_blake3_and_normal_form, LIMB_LEN, N_LIMBS};
 use bitvm::{bigint::U256, hash::blake3::blake3_compute_script_with_limb, treepp::*};
+use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static WIRE_COUNTER: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
 
 #[derive(Clone, Debug)]
 pub struct Wire {
+    pub id: u64,
     pub label0: S,
     pub label1: S,
     pub hash0: S,
@@ -24,7 +29,11 @@ impl Wire {
         let label1 = S::random();
         let hash0 = label0.hash();
         let hash1 = label1.hash();
+        // A strictly monotonic sequence is sufficient for assigning
+        // unique IDs, so relaxed ordering is enough here.
+        let id = WIRE_COUNTER.fetch_add(1, Ordering::Relaxed);
         Self {
+            id,
             label0,
             label1,
             hash0,


### PR DESCRIPTION
## Summary
- add gate count to binary serialization format
- update documentation for the new format
- extend tests to cover `append_gates`
- use relaxed ordering when generating wire IDs

## Testing
- `cargo check --quiet`
- `cargo test test_gate_serialization --quiet`
- `cargo build --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688330a8a2288326b7f358567a4e5c44