### PR TITLE
Add GateWriter for streaming gate records

### DIFF
--- a/examples/groth16_gate_writer.rs
+++ b/examples/groth16_gate_writer.rs
@@ -1,0 +1,73 @@
+use ark_crypto_primitives::snark::{CircuitSpecificSetupSNARK, SNARK};
+use ark_ec::pairing::Pairing;
+use ark_ff::{PrimeField, UniformRand};
+use ark_groth16::Groth16;
+use ark_relations::{
+    lc,
+    r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
+};
+use ark_std::{
+    rand::{RngCore, SeedableRng},
+    test_rng,
+};
+use garbled_snark_verifier::bag::*;
+use garbled_snark_verifier::circuits::{
+    bn254::{fr::Fr, g1::G1Affine, g2::G2Affine},
+    groth16::groth16_verifier_evaluate_montgomery,
+};
+use garbled_snark_verifier::core::serialization::{GateWriter, read_gates};
+
+#[derive(Copy, Clone)]
+struct DummyCircuit<F: PrimeField> {
+    pub a: Option<F>,
+    pub b: Option<F>,
+    pub num_variables: usize,
+    pub num_constraints: usize,
+}
+
+impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
+    fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
+        let a = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+        let b = cs.new_witness_variable(|| self.b.ok_or(SynthesisError::AssignmentMissing))?;
+        let c = cs.new_input_variable(|| {
+            let a = self.a.ok_or(SynthesisError::AssignmentMissing)?;
+            let b = self.b.ok_or(SynthesisError::AssignmentMissing)?;
+            Ok(a * b)
+        })?;
+        for _ in 0..(self.num_variables - 3) {
+            let _ = cs.new_witness_variable(|| self.a.ok_or(SynthesisError::AssignmentMissing))?;
+        }
+        for _ in 0..self.num_constraints - 1 {
+            cs.enforce_constraint(lc!() + a, lc!() + b, lc!() + c)?;
+        }
+        cs.enforce_constraint(lc!(), lc!(), lc!())?;
+        Ok(())
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
+    let circuit = DummyCircuit::<<ark_bn254::Bn254 as Pairing>::ScalarField> {
+        a: Some(<ark_bn254::Bn254 as Pairing>::ScalarField::rand(&mut rng)),
+        b: Some(<ark_bn254::Bn254 as Pairing>::ScalarField::rand(&mut rng)),
+        num_variables: 10,
+        num_constraints: 64,
+    };
+    let (pk, vk) = Groth16::<ark_bn254::Bn254>::setup(circuit, &mut rng).unwrap();
+    let c = circuit.a.unwrap() * circuit.b.unwrap();
+    let proof = Groth16::<ark_bn254::Bn254>::prove(&pk, circuit, &mut rng).unwrap();
+    let public = Fr::wires_set(c);
+    let proof_a = G1Affine::wires_set_montgomery(proof.a);
+    let proof_b = G2Affine::wires_set_montgomery(proof.b);
+    let proof_c = G1Affine::wires_set_montgomery(proof.c);
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("verifier_gates.bin");
+    Circuit::start_gate_recording(&path)?;
+    let (result, _gc) =
+        groth16_verifier_evaluate_montgomery(public, proof_a, proof_b, proof_c, vk, false);
+    Circuit::finish_gate_recording()?;
+    println!("Verification result: {}", result.borrow().get_value());
+    let records = read_gates(&path)?;
+    println!("Stored {} gate records", records.len());
+    Ok(())
+}

--- a/examples/groth16_gate_writer.rs
+++ b/examples/groth16_gate_writer.rs
@@ -15,7 +15,7 @@ use garbled_snark_verifier::circuits::{
     bn254::{fr::Fr, g1::G1Affine, g2::G2Affine},
     groth16::groth16_verifier_evaluate_montgomery,
 };
-use garbled_snark_verifier::core::serialization::{GateWriter, read_gates};
+use garbled_snark_verifier::core::serialization::read_gates;
 
 #[derive(Copy, Clone)]
 struct DummyCircuit<F: PrimeField> {

--- a/src/core/circuit.rs
+++ b/src/core/circuit.rs
@@ -1,4 +1,5 @@
 use crate::{bag::*, core::gate::GateCount};
+use std::io;
 
 pub struct Circuit(pub Wires, pub Vec<Gate>);
 
@@ -42,6 +43,22 @@ impl Circuit {
             gc.0[gate.gate_type as usize] += 1;
         }
         gc
+    }
+
+    /// Begin streaming all subsequently evaluated gates into the given file.
+    pub fn start_gate_recording<P: AsRef<std::path::Path>>(path: P) -> io::Result<()> {
+        let writer = crate::core::serialization::GateWriter::new(path)?;
+        crate::core::serialization::install_gate_writer(writer);
+        Ok(())
+    }
+
+    /// Finish streaming gates and close the writer.
+    pub fn finish_gate_recording() -> io::Result<()> {
+        if let Some(writer) = crate::core::serialization::take_gate_writer() {
+            writer.finish()
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -1,4 +1,5 @@
 use crate::bag::*;
+use crate::core::serialization::GLOBAL_GATE_WRITER;
 use crate::core::utils::{LIMB_LEN, N_LIMBS, bit_to_usize, convert_between_blake3_and_normal_form};
 use bitvm::{bigint::U256, hash::blake3::blake3_compute_script_with_limb, treepp::*};
 use std::ops::{Add, AddAssign};
@@ -160,6 +161,12 @@ impl Gate {
             self.wire_a.borrow().get_value(),
             self.wire_b.borrow().get_value(),
         ));
+        if let Some(ref mut w) = *crate::core::serialization::GLOBAL_GATE_WRITER
+            .lock()
+            .unwrap()
+        {
+            w.record_gate(self).expect("failed to record gate");
+        }
     }
 
     pub fn garbled(&self) -> Vec<S> {

--- a/src/core/gate.rs
+++ b/src/core/gate.rs
@@ -1,5 +1,4 @@
 use crate::bag::*;
-use crate::core::serialization::GLOBAL_GATE_WRITER;
 use crate::core::utils::{LIMB_LEN, N_LIMBS, bit_to_usize, convert_between_blake3_and_normal_form};
 use bitvm::{bigint::U256, hash::blake3::blake3_compute_script_with_limb, treepp::*};
 use std::ops::{Add, AddAssign};

--- a/src/core/serialization.rs
+++ b/src/core/serialization.rs
@@ -1,6 +1,8 @@
+use once_cell::sync::Lazy;
 use std::fs::OpenOptions;
 use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
+use std::sync::Mutex;
 
 use crate::bag::Gate;
 
@@ -14,6 +16,55 @@ pub struct GateRecord {
     pub wire_a: u64,
     pub wire_b: u64,
     pub wire_c: u64,
+}
+
+/// Streaming writer for gates that updates the count on `finish()`.
+pub struct GateWriter {
+    writer: BufWriter<std::fs::File>,
+    count: u64,
+}
+
+impl GateWriter {
+    /// Create a new writer and truncate any existing file.
+    pub fn new<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(true)
+            .open(path)?;
+        let mut writer = BufWriter::new(file);
+        writer.write_all(FILE_MAGIC)?;
+        writer.write_all(&0u64.to_le_bytes())?;
+        Ok(Self { writer, count: 0 })
+    }
+
+    /// Append a single gate record to the file.
+    pub fn record_gate(&mut self, gate: &Gate) -> io::Result<()> {
+        serialize_gate(&mut self.writer, gate)?;
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Finalize writing by updating the gate count header.
+    pub fn finish(mut self) -> io::Result<()> {
+        self.writer.flush()?;
+        let file = self.writer.get_mut();
+        file.seek(SeekFrom::Start(FILE_MAGIC.len() as u64))?;
+        file.write_all(&self.count.to_le_bytes())?;
+        file.flush()
+    }
+}
+
+/// Global writer used when evaluating gates.
+pub static GLOBAL_GATE_WRITER: Lazy<Mutex<Option<GateWriter>>> = Lazy::new(|| Mutex::new(None));
+
+pub(crate) fn install_gate_writer(writer: GateWriter) {
+    *GLOBAL_GATE_WRITER.lock().unwrap() = Some(writer);
+}
+
+pub(crate) fn take_gate_writer() -> Option<GateWriter> {
+    GLOBAL_GATE_WRITER.lock().unwrap().take()
 }
 
 fn write_id<W: Write>(mut writer: W, id: u64) -> io::Result<()> {
@@ -122,6 +173,7 @@ pub fn read_gates<P: AsRef<Path>>(path: P) -> io::Result<Vec<GateRecord>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bag::Circuit;
     use crate::circuits::bn254::fp254impl::Fp254Impl;
     use crate::circuits::bn254::fq::Fq;
 
@@ -148,5 +200,25 @@ mod tests {
             records[circuit.1.len()].operation,
             circuit.1[0].gate_type as u8
         );
+    }
+
+    #[test]
+    fn test_gate_writer_stream() {
+        let a = Fq::random();
+        let b = Fq::random();
+        let circuit = Fq::mul_montgomery(
+            Fq::wires_set(Fq::as_montgomery(a)),
+            Fq::wires_set(Fq::as_montgomery(b)),
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stream.bin");
+        Circuit::start_gate_recording(&path).unwrap();
+        for mut g in circuit.1.clone() {
+            g.evaluate();
+        }
+        Circuit::finish_gate_recording().unwrap();
+        let records = read_gates(&path).unwrap();
+        assert_eq!(records.len(), circuit.1.len());
     }
 }


### PR DESCRIPTION
## Summary
- implement `GateWriter` to stream gate records to disk
- add global writer that `Gate::evaluate` uses
- provide start/finish helpers on `Circuit`
- add test verifying streaming
- include example showing Groth16 verifier gates written to disk

## Testing
- `cargo test --quiet core::serialization::tests::test_gate_writer_stream -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6884d84db0e883269db92bcb63accc06