### PR TITLE
Add thread result export and global snapshot updates

### DIFF
--- a/examples/file_circuit_example.rs
+++ b/examples/file_circuit_example.rs
@@ -74,6 +74,132 @@ struct ThreadStats {
     xor_result: S,
 }
 
+#[derive(Serialize)]
+struct ThreadResultExport {
+    thread_id: usize,
+    memory_usage_gb: f64,
+    xor_result_hex: String,
+    error: Option<String>,
+    hash160: Option<String>,
+}
+
+#[derive(Serialize)]
+struct MemoryPoint {
+    elapsed_seconds: f64,
+    memory_gb: f64,
+    active_workers: usize,
+}
+
+#[derive(Serialize)]
+struct MemoryAnalysisExport {
+    baseline_gb: f64,
+    peak_gb: f64,
+    final_gb: f64,
+    growth_rate_gb_per_hour: f64,
+    efficiency_gb_per_worker: f64,
+    peak_workers: usize,
+    memory_timeline: Vec<MemoryPoint>,
+}
+
+#[derive(Serialize)]
+struct ExperimentInfo {
+    timestamp: u64,
+    config_file_path: String,
+    circuit_file_path: String,
+    total_runtime_seconds: f64,
+    status: String,
+}
+
+#[derive(Serialize)]
+struct PerformanceExport {
+    total_gates_processed: usize,
+    peak_throughput_gates_per_sec: f64,
+    memory_per_gate_bytes: f64,
+}
+
+#[derive(Serialize)]
+struct ExperimentExport {
+    experiment: ExperimentInfo,
+    memory_analysis: MemoryAnalysisExport,
+    performance: PerformanceExport,
+    threads: Vec<ThreadResultExport>,
+}
+
+fn export_experiment_results_to_toml(
+    snapshot: &garbled_snark_verifier::process_monitor::MonitorSnapshot,
+    results: &[ThreadStats],
+    config_path: &str,
+    circuit_path: &str,
+    save_dir: &str,
+) -> std::io::Result<()> {
+    let experiment = ExperimentInfo {
+        timestamp: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+        config_file_path: config_path.to_string(),
+        circuit_file_path: circuit_path.to_string(),
+        total_runtime_seconds: snapshot.runtime.as_secs_f64(),
+        status: "completed".to_string(),
+    };
+
+    let timeline = snapshot
+        .system
+        .memory_history
+        .iter()
+        .map(|(d, m)| MemoryPoint {
+            elapsed_seconds: d.as_secs_f64(),
+            memory_gb: *m,
+            active_workers: snapshot.system.active_workers,
+        })
+        .collect();
+
+    let memory_analysis = MemoryAnalysisExport {
+        baseline_gb: snapshot.system.memory_baseline_gb,
+        peak_gb: snapshot.system.memory_peak_gb,
+        final_gb: snapshot.system.process_memory_gb,
+        growth_rate_gb_per_hour: snapshot.system.memory_rate_gb_per_hour,
+        efficiency_gb_per_worker: snapshot.system.memory_per_worker_gb,
+        peak_workers: snapshot.system.max_workers,
+        memory_timeline: timeline,
+    };
+
+    let performance = PerformanceExport {
+        total_gates_processed: snapshot.total_gates_processed,
+        peak_throughput_gates_per_sec: snapshot.total_speed,
+        memory_per_gate_bytes: if snapshot.total_gates_processed > 0 {
+            (snapshot.system.memory_peak_gb * 1024.0 * 1024.0 * 1024.0)
+                / snapshot.total_gates_processed as f64
+        } else {
+            0.0
+        },
+    };
+
+    let mut threads = Vec::new();
+    for (snap, stats) in snapshot.threads.iter().zip(results.iter()) {
+        threads.push(ThreadResultExport {
+            thread_id: snap.thread_id,
+            memory_usage_gb: snap.memory_usage_gb,
+            xor_result_hex: stats.xor_result.to_hex(),
+            error: snap.error_message.clone(),
+            hash160: snap.input_hash160.clone(),
+        });
+    }
+
+    let export = ExperimentExport {
+        experiment,
+        memory_analysis,
+        performance,
+        threads,
+    };
+
+    let toml_str = toml::to_string_pretty(&export).unwrap();
+    std::fs::create_dir_all(save_dir)?;
+    let path = format!("{}/experiment.toml", save_dir);
+    std::fs::write(&path, toml_str)?;
+    Ok(())
+}
+
 fn get_system_memory_info() -> Option<(f64, f64)> {
     use std::fs;
     
@@ -339,6 +465,7 @@ fn run_multiple_garbling<H: digest::Digest + Default + Clone>(
                         pending_tasks_clone.lock().unwrap().len(),
                     );
                     guard.update_storage_metrics();
+                    guard.save_snapshot_to_file();
                 }
             }
         }
@@ -435,6 +562,8 @@ fn spawn_worker_task<H: digest::Digest + Default + Clone>(
     thread::spawn(move || {
         let start_time = Instant::now();
         let mut rng = ChaCha8Rng::seed_from_u64(task.task_id as u64);
+        let thread_dir = format!("{}/{}", task.timestamped_save_path, task.task_id);
+        let _ = fs::create_dir_all(&thread_dir);
         
         // Create a new FileGateProvider for this thread first to get gate count
         let file_gate_provider = match FileGateProvider::new(&task.circuit_file_path) {
@@ -491,15 +620,28 @@ fn spawn_worker_task<H: digest::Digest + Default + Clone>(
         ) {
             Ok((_, xor_result)) => {
                 let duration = start_time.elapsed();
-                
+
                 // Update final status and result
                 if let Some(monitor) = ProcessMonitor::instance() {
                     if let Ok(guard) = monitor.lock() {
                         guard.update_thread_status(task.task_id, ThreadStatus::Finished);
                         guard.update_thread_result(task.task_id, xor_result);
+                        guard.save_snapshot_to_file();
                     }
                 }
-                
+
+                let result_export = ThreadResultExport {
+                    thread_id: task.task_id,
+                    memory_usage_gb: 0.0,
+                    xor_result_hex: xor_result.to_hex(),
+                    error: None,
+                    hash160: None,
+                };
+                let path = format!("{}/result.toml", thread_dir);
+                if let Ok(text) = toml::to_string_pretty(&result_export) {
+                    let _ = fs::write(path, text);
+                }
+
                 Ok(ThreadStats {
                     thread_id: task.task_id,
                     gates_processed: thread_circuit.gates.gate_count().unwrap_or(0),
@@ -512,7 +654,19 @@ fn spawn_worker_task<H: digest::Digest + Default + Clone>(
                 if let Some(monitor) = ProcessMonitor::instance() {
                     if let Ok(guard) = monitor.lock() {
                         guard.update_thread_error(task.task_id, format!("{:?}", e));
+                        guard.save_snapshot_to_file();
                     }
+                }
+                let result_export = ThreadResultExport {
+                    thread_id: task.task_id,
+                    memory_usage_gb: 0.0,
+                    xor_result_hex: String::new(),
+                    error: Some(format!("{:?}", e)),
+                    hash160: None,
+                };
+                let path = format!("{}/result.toml", thread_dir);
+                if let Ok(text) = toml::to_string_pretty(&result_export) {
+                    let _ = fs::write(path, text);
                 }
                 Err(e)
             }
@@ -974,6 +1128,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     stats.duration.as_secs_f64(),
                     gates_per_sec
                 );
+            }
+
+            if let Some(monitor) = ProcessMonitor::instance() {
+                if let Ok(guard) = monitor.lock() {
+                    let snap = guard.get_snapshot();
+                    let save_dir = guard.save_folder();
+                    if let Err(e) = export_experiment_results_to_toml(
+                        &snap,
+                        &results,
+                        &config_file_path,
+                        &circuit_file_path,
+                        &save_dir,
+                    ) {
+                        eprintln!("Failed to export results: {}", e);
+                    }
+                }
             }
         }
         Err(e) => {

--- a/src/core/s.rs
+++ b/src/core/s.rs
@@ -73,6 +73,15 @@ impl fmt::Debug for S {
     }
 }
 
+impl serde::Serialize for S {
+    fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
+    where
+        SER: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
 impl Add for S {
     type Output = Self;
 

--- a/src/process_monitor.rs
+++ b/src/process_monitor.rs
@@ -10,11 +10,11 @@ use std::{
 };
 
 use once_cell::sync::Lazy;
-// use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::S;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub enum ThreadStatus {
     Starting,
     Running,
@@ -23,23 +23,26 @@ pub enum ThreadStatus {
     Error,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ThreadMetrics {
     pub thread_id: usize,
+    #[serde(serialize_with = "serialize_atomic_usize")]
     pub current_gate: Arc<AtomicUsize>,
     pub total_gates: usize,
     pub gates_per_second: f64,
     pub memory_usage_gb: f64,
     pub status: ThreadStatus,
     pub xor_result: Option<S>,
+    #[serde(serialize_with = "serialize_instant")]
     pub start_time: Instant,
+    #[serde(serialize_with = "serialize_duration")]
     pub duration: Duration,
     pub speed_history: VecDeque<f64>,
     pub error_message: Option<String>,
     pub input_hash160: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SystemMetrics {
     pub total_memory_gb: f64,
     pub available_memory_gb: f64,
@@ -53,13 +56,16 @@ pub struct SystemMetrics {
     pub save_folder_size_gb: f64,
     pub disk_free_gb: f64,
     pub files_written: usize,
+    #[serde(serialize_with = "serialize_memory_history")]
+    pub memory_history: Vec<(Duration, f64)>,
+    pub memory_per_worker_gb: f64,
     // Global context from config
     pub total_garbling_tasks: usize,
     pub completed_tasks: usize,
     pub failed_tasks: usize,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct CircuitInfo {
     pub num_wire: usize,
     pub input_wire_count: usize,
@@ -74,6 +80,7 @@ pub struct ProcessMonitor {
     circuit: CircuitInfo,
     start_time: Instant,
     save_folder_path: String,
+    stats_lock: Arc<Mutex<()>>,
 }
 
 static PROCESS_MONITOR: Lazy<Arc<Mutex<Option<ProcessMonitor>>>> = 
@@ -102,6 +109,8 @@ impl ProcessMonitor {
                 save_folder_size_gb: 0.0,
                 disk_free_gb: 0.0,
                 files_written: 0,
+                memory_history: Vec::new(),
+                memory_per_worker_gb: 0.0,
                 total_garbling_tasks,
                 completed_tasks: 0,
                 failed_tasks: 0,
@@ -109,6 +118,7 @@ impl ProcessMonitor {
             circuit: circuit_info,
             start_time: Instant::now(),
             save_folder_path,
+            stats_lock: Arc::new(Mutex::new(())),
         };
 
         *PROCESS_MONITOR.lock().unwrap() = Some(monitor);
@@ -123,6 +133,7 @@ impl ProcessMonitor {
                 circuit: monitor.circuit.clone(),
                 start_time: monitor.start_time,
                 save_folder_path: monitor.save_folder_path.clone(),
+                stats_lock: Arc::clone(&monitor.stats_lock),
             }))
         })
     }
@@ -208,6 +219,10 @@ impl ProcessMonitor {
         system.failed_tasks += 1;
     }
 
+    pub fn save_folder(&self) -> String {
+        self.save_folder_path.clone()
+    }
+
     pub fn update_system_metrics(
         &self,
         total_memory_gb: f64,
@@ -229,9 +244,16 @@ impl ProcessMonitor {
         // Calculate memory growth rate (GB/hour)
         let runtime_hours = self.start_time.elapsed().as_secs_f64() / 3600.0;
         if runtime_hours > 0.0 {
-            system.memory_rate_gb_per_hour = 
+            system.memory_rate_gb_per_hour =
                 (process_memory_gb - system.memory_baseline_gb) / runtime_hours;
         }
+
+        system.memory_history.push((self.start_time.elapsed(), process_memory_gb));
+        system.memory_per_worker_gb = if system.active_workers > 0 {
+            process_memory_gb / system.active_workers as f64
+        } else {
+            process_memory_gb
+        };
     }
 
     pub fn update_storage_metrics(&self) {
@@ -353,9 +375,18 @@ impl ProcessMonitor {
             overall_progress,
         }
     }
+
+    pub fn save_snapshot_to_file(&self) {
+        if let Ok(_guard) = self.stats_lock.lock() {
+            if let Ok(snapshot) = toml::to_string_pretty(&self.get_snapshot()) {
+                let path = format!("{}/global_stats.toml", self.save_folder_path);
+                let _ = std::fs::write(path, snapshot);
+            }
+        }
+    }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ThreadSnapshot {
     pub thread_id: usize,
     pub current_gate: usize,
@@ -363,19 +394,56 @@ pub struct ThreadSnapshot {
     pub gates_per_second: f64,
     pub memory_usage_gb: f64,
     pub status: ThreadStatus,
+    #[serde(serialize_with = "serialize_duration")]
     pub duration: Duration,
     pub progress_percent: f64,
     pub error_message: Option<String>,
     pub input_hash160: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct MonitorSnapshot {
     pub threads: Vec<ThreadSnapshot>,
     pub system: SystemMetrics,
     pub circuit: CircuitInfo,
+    #[serde(serialize_with = "serialize_duration")]
     pub runtime: Duration,
     pub total_gates_processed: usize,
     pub total_speed: f64,
     pub overall_progress: f64,
+}
+
+fn serialize_duration<S>(d: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_f64(d.as_secs_f64())
+}
+
+fn serialize_instant<S>(i: &Instant, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_f64(i.elapsed().as_secs_f64())
+}
+
+fn serialize_atomic_usize<S>(a: &Arc<AtomicUsize>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_u64(a.load(Ordering::Relaxed) as u64)
+}
+
+fn serialize_memory_history<S>(
+    history: &Vec<(Duration, f64)>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let list: Vec<(f64, f64)> = history
+        .iter()
+        .map(|(d, m)| (d.as_secs_f64(), *m))
+        .collect();
+    list.serialize(serializer)
 }


### PR DESCRIPTION
## Summary
- fix duplicate `Serialize` implementation on type `S`
- derive `Serialize` for `ThreadStatus`
- add snapshot file updates in `ProcessMonitor`
- write per-thread result files and save snapshots during execution

## Testing
- `cargo build --quiet`
- `cargo clippy --examples --quiet`
- `cargo test --quiet --lib` *(aborted: test `test_fq_sqrt_montgomery` running over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_688a7d17bdbc8326af92757b1d2b3985